### PR TITLE
Catch global yup errors as valid errors and store them properly

### DIFF
--- a/src/helpers.yup.js
+++ b/src/helpers.yup.js
@@ -30,12 +30,14 @@ export function extractYupErrors(yupError) {
 
     const errors = {}
     for (const err of yupError.inner) {
-        if (!err.path) throw yupError
-
-        const path = fromYupPath(err.path)
-        const message = adaptMessage(err.message)
-        if (!errors[path]) {
-            errors[path] = message
+        if (!err.path) {
+            errors["__global"] = err.message
+        } else {
+            const path = fromYupPath(err.path)
+            const message = adaptMessage(err.message)
+            if (!errors[path]) {
+                errors[path] = message
+            }
         }
     }
 

--- a/src/useFormist.js
+++ b/src/useFormist.js
@@ -53,6 +53,7 @@ const useFormist = (initialValues, options) => {
         change: changes.change,
         isChanged: changes.isChanged,
         errors: validation.errors,
+        globalError: validation.errors["__global"],
         error: validation.getError,
         setError: validation.setError,
         isValid: validation.isValid,

--- a/src/validation.js
+++ b/src/validation.js
@@ -28,6 +28,6 @@ async function validate(options, values, path) {
         }
     } catch (err) {
         if (!isYupError(err)) throw err
-        return err
+        return Promise.resolve(err)
     }
 }

--- a/tests/helpers.yup.test.js
+++ b/tests/helpers.yup.test.js
@@ -16,6 +16,26 @@ test("extract yup errors", () => {
     })
 })
 
+test("extract yup global error", () => {
+    let schema = yup
+        .object()
+        .shape({
+            firstName: yup.string(),
+            age: yup.number(),
+        })
+        .test(
+            "not-both-empty",
+            "one of firstName and age should have a value",
+            obj => obj.firstName || obj.age,
+        )
+
+    const result = extractYupErrors(validate({}, schema))
+
+    expect(result).toStrictEqual({
+        __global: "one of firstName and age should have a value",
+    })
+})
+
 test("extract yup errors on arrays", () => {
     let schema = yup.object().shape({
         address: yup.array().of(

--- a/tests/useFormist.validation.yup.test.js
+++ b/tests/useFormist.validation.yup.test.js
@@ -82,6 +82,28 @@ test("non yup errors", async () => {
     }
 })
 
+test("global error", async () => {
+    expect.assertions(1)
+    let schema = yup
+        .object()
+        .shape({
+            firstName: yup.string(),
+            age: yup.number(),
+        })
+        .test(
+            "not-both-empty",
+            "one of firstName and age should have a value",
+            obj => obj.firstName || obj.age,
+        )
+    const { result } = renderHook(() => useFormist({}, { schema }))
+
+    await act(() => result.current.validate())
+
+    expect(result.current.globalError).toBe(
+        "one of firstName and age should have a value",
+    )
+})
+
 test("many field, one change + onBlur", async () => {
     const schema = nameAndAgeSchema
     const { result } = renderHook(() => useFormist({}, { schema }))


### PR DESCRIPTION
YUP errors that are not tied to a specific path are currently thrown by the validator.
This PR allows to catch them properly and stores the error in a new globalError property, so that it can be used / shown by components.